### PR TITLE
Using AppDbContext in HomeController to load Posts.

### DIFF
--- a/CircleApp/Controllers/HomeController.cs
+++ b/CircleApp/Controllers/HomeController.cs
@@ -1,4 +1,6 @@
+using CircleApp.Data;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using System.Diagnostics;
 
 namespace CircleApp.Controllers
@@ -6,14 +8,17 @@ namespace CircleApp.Controllers
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
+        private readonly AppDbContext _context;
 
-        public HomeController(ILogger<HomeController> logger)
+        public HomeController(ILogger<HomeController> logger, AppDbContext contect)
         {
             _logger = logger;
+            _context = contect;
         }
 
-        public IActionResult Index()
+        public async Task<IActionResult> Index()
         {
+            var allPosts = await _context.Posts.Include(n => n.User).ToListAsync();
             return View();
         }
     }


### PR DESCRIPTION
Notes:
- In the HomeController
- Declare a Private readonly field of type AppDbContext,
- Pass it on your constructor and initialize the value.
- In the Index method, retrieve all Post from the DB using the readonly field.